### PR TITLE
Add optional envvar file parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Setup the Confluence login information environment variables, please refer the [
 source envvar
 ```
 
+Alternatively, you can provide the path to the environment variables file directly when running the exporter:
+
+```
+confluence-space-exporter --envvar ./envvar -k CAP -t xml
+```
+
 ## Usage
 
 ```
@@ -43,9 +49,11 @@ Options:
   --version   Show version number                                      [boolean]
   -k, --key   Confluence space key                                    [required]
   -t, --type  Export file type: xml, html or pdf                      [required]
+  -e, --envvar  Path to environment variables file
 
 Examples:
   confluence-space-exporter -k CAP -t xml  Export Confluence space CAP to XML file
+  confluence-space-exporter --envvar ./envvar -k CAP -t xml
 ```
 
 ## Example

--- a/cse.js
+++ b/cse.js
@@ -1,17 +1,66 @@
-#!/usr/bin/env node 
+#!/usr/bin/env node
+"use strict";
 /**
  * Confluence Space Exporter Starter
  */
-const exporter = require('./lib/exporter')
 
-const argv = require('yargs')
+const fs = require('fs')
+const path = require('path')
+const yargs = require('yargs')
+
+const argv = yargs
   .usage('Usage: $0 -k [key] -t [type]')
   .example('$0 -k CAP -t xml', 'Export Confluence space CAP to XML file')
+  .example('$0 --envvar ./envvar -k CAP -t xml', 'Export space using variables from the specified file')
   .alias('k', 'key')
   .describe('k', 'Confluence space key')
   .alias('t', 'type')
   .describe('t', 'Export file type: xml, html or pdf')
+  .option('e', {
+    alias: 'envvar',
+    describe: 'Path to environment variables file',
+    type: 'string'
+  })
   .demandOption(['k', 't'])
   .argv
+
+if (argv.envvar) {
+  const envFilePath = path.resolve(argv.envvar)
+  if (!fs.existsSync(envFilePath)) {
+    console.error('Error: The environment variables file does not exist:', envFilePath)
+    process.exit(1)
+  }
+
+  try {
+    const envFileContent = fs.readFileSync(envFilePath, 'utf8')
+    envFileContent.split(/\r?\n/).forEach((line) => {
+      const trimmedLine = line.trim()
+
+      if (!trimmedLine || trimmedLine.startsWith('#')) {
+        return
+      }
+
+      const match = trimmedLine.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/)
+
+      if (!match) {
+        return
+      }
+
+      const key = match[1]
+      let value = match[2].trim()
+
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1)
+      }
+
+      process.env[key] = value
+    })
+  } catch (error) {
+    console.error('Error loading environment variables file:', error.message)
+    process.exit(1)
+  }
+}
+
+const exporter = require('./lib/exporter')
 
 exporter(argv.key, argv.type)


### PR DESCRIPTION
## Summary
- add an optional `--envvar`/`-e` flag to the CLI, loading variables from the specified file before starting the export
- document the new environment file option and example usage in the README

## Testing
- node cse.js --help

------
https://chatgpt.com/codex/tasks/task_b_68e4446e78a48330865959f1529ed899