### PR TITLE
Add verbose CLI logging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,33 @@ Opções:
   --version    Mostra a versão                                         [boolean]
   -k, --key    Chave do espaço no Confluence                         [obrigatório]
   -t, --type   Tipo de exportação: xml, html ou pdf                  [obrigatório]
+  -v, --verbose Ativa logs detalhados para troubleshooting               [boolean]
   -e, --envvar Caminho para o arquivo de variáveis de ambiente
 
 Exemplos:
   confluence-space-exporter -k CAP -t xml
   confluence-space-exporter --envvar ./envvar -k CAP -t xml
+  confluence-space-exporter -k CAP -t xml --verbose
+  confluence-space-exporter -k CAP -t xml -v
+```
+
+### Modo verbose
+
+Utilize a flag opcional `--verbose` (ou `-v`) para habilitar um modo de execução com logs detalhados. Esse recurso é indicado para troubleshooting ou para acompanhar cada etapa do processo de exportação em ambientes avançados.
+
+Quando ativado, o modo verbose exibe:
+
+- Informações adicionais sobre as variáveis de configuração utilizadas (sem revelar senhas).
+- Etapas de autenticação e chamadas à API do Confluence, incluindo respostas retornadas.
+- Progresso detalhado do download, com registro de bytes transferidos e cabeçalhos HTTP.
+- Relatórios de tempo de execução das principais fases (geração da exportação e download).
+- Erros com stack trace completo para facilitar a identificação de problemas.
+
+Exemplos:
+
+```
+confluence-space-exporter -k SPACE_KEY -t xml --verbose
+confluence-space-exporter -k SPACE_KEY -t xml -v
 ```
 
 ## Exemplo

--- a/cse.js
+++ b/cse.js
@@ -16,6 +16,12 @@ const argv = yargs
   .describe('k', 'Confluence space key')
   .alias('t', 'type')
   .describe('t', 'Export file type: xml, html or pdf')
+  .option('v', {
+    alias: 'verbose',
+    describe: 'Enable verbose logging output',
+    type: 'boolean',
+    default: false
+  })
   .option('e', {
     alias: 'envvar',
     describe: 'Path to environment variables file',
@@ -63,4 +69,4 @@ if (argv.envvar) {
 
 const exporter = require('./lib/exporter')
 
-exporter(argv.key, argv.type)
+exporter(argv.key, argv.type, { verbose: argv.verbose })

--- a/lib/confluence-client-promise.js
+++ b/lib/confluence-client-promise.js
@@ -8,7 +8,7 @@ const request = require('request-promise')
 const Promise = require('promise')
 
 class ConfluenceClient {
-  constructor (protocol, host, port, username, password) {
+  constructor (protocol, host, port, username, password, logger) {
     this.protocol = protocol
     this.host = host
     this.port = port
@@ -20,15 +20,47 @@ class ConfluenceClient {
       user: this.username,
       password: this.password
     }
+    this.logger = logger
+    if (this.logger && this.logger.isVerbose()) {
+      this.logger.debug('Initialized ConfluenceClient', {
+        baseurl: this.baseurl,
+        username: this.username
+      })
+    }
   }
 
   // API request generator
   async makeRequest (options) {
     try {
+      if (this.logger && this.logger.isVerbose()) {
+        const safeOptions = {
+          method: options.method,
+          url: options.url,
+          headers: options.headers,
+          hasBody: Boolean(options.body)
+        }
+        this.logger.debug('Sending request to Confluence API', safeOptions)
+      }
       const response = await request(options)
+      if (this.logger && this.logger.isVerbose()) {
+        this.logger.debug('Received response from Confluence API', {
+          url: options.url,
+          status: response && response.statusCode ? response.statusCode : 'success',
+          type: typeof response
+        })
+      }
       return response
     } catch (err) {
-      console.log(err.message)
+      if (this.logger) {
+        this.logger.error('Confluence API request failed')
+        if (this.logger.isVerbose() && err && err.stack) {
+          this.logger.error(err.stack)
+        } else {
+          this.logger.error(err && err.message ? err.message : err)
+        }
+      } else {
+        console.log(err.message)
+      }
       process.exit(1)
     }
   }
@@ -91,6 +123,9 @@ class ConfluenceClient {
 
   // Retrive token to access plugin
   async pluginLogin () {
+    if (this.logger && this.logger.isVerbose()) {
+      this.logger.debug('Authenticating via Confluence PDF export plugin')
+    }
     const loginString = '<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:rpc="http://rpc.confluence.atlassian.com">' +
     '<soapenv:Header/>' +
     '<soapenv:Body>' +
@@ -110,6 +145,9 @@ class ConfluenceClient {
     const data = await this.makeRequest(options)
     const pattern = /xsd:string">(.*)<\/loginReturn/
     const token = data.match(pattern)[1]
+    if (this.logger && this.logger.isVerbose()) {
+      this.logger.debug('Authentication token retrieved successfully')
+    }
     return token
   }
 
@@ -137,6 +175,9 @@ class ConfluenceClient {
     const data = await this.makeRequest(options)
     const pattern = /xsd:string">(.*)<\/exportSpaceReturn/
     const downloadLink = data.match(pattern)[1]
+    if (this.logger && this.logger.isVerbose()) {
+      this.logger.debug('PDF export download link retrieved', downloadLink)
+    }
     return downloadLink
   }
 

--- a/lib/exporter.js
+++ b/lib/exporter.js
@@ -1,7 +1,3 @@
-/**
- * Export a Confluence space into XML or HTML or PDF
- */
-
 'use strict'
 
 const ConfluenceClient = require('./confluence-client-promise')
@@ -10,89 +6,156 @@ const fs = require('fs')
 const path = require('path')
 const request = require('request')
 const moment = require('moment')
+const Logger = require('./logger')
 
-const confluence = new ConfluenceClient(process.env.PROTOCOL, process.env.HOST, process.env.PORT, process.env.USERNAME, process.env.PASSWORD)
-
-function downloadProgress (key, received, total) {
+function downloadProgress (logger, key, received, total) {
   const percentage = ((received * 100) / total).toFixed(2)
-  console.log(percentage + " % has been downloaded for " + key)
+  logger.info(percentage + ' % has been downloaded for ' + key)
+  logger.debug(`Download progress for ${key}: ${received} of ${total} bytes`)
 }
 
-async function downloadExportFile (key, type, downloadLink) {
+async function downloadExportFile (logger, confluence, key, type, downloadLink) {
+  logger.time(`download:${key}`)
   return new Promise(async function (resolve, reject) {
-    const spaceDetail = await confluence.getSpace({ key: key })
-    let savePath = path.join(process.env.HOST + '-' + key + '-' + spaceDetail.name.replace(/[^A-Z0-9]/ig, '_') + '.' + type + '.zip')
-    if (type === 'pdf') {
-      savePath = path.join(process.env.HOST + '-' + key + '-' + spaceDetail.name.replace(/[^A-Z0-9]/ig, '_') + '.pdf')
-    }
-    const writer = fs.createWriteStream(savePath)
-    let receivedBytes = 0
-    let totalBytes = 0
-    const options = {
-      url: downloadLink,
-      headers: { 'Content-Type': 'application/json' },
-      auth: {
-        user: process.env.USERNAME,
-        password: process.env.PASSWORD
+    try {
+      logger.debug('Fetching space details to determine export file path')
+      const spaceDetail = await confluence.getSpace({ key: key })
+      logger.debug('Space details received', spaceDetail)
+      let savePath = path.join(process.env.HOST + '-' + key + '-' + spaceDetail.name.replace(/[^A-Z0-9]/ig, '_') + '.' + type + '.zip')
+      if (type === 'pdf') {
+        savePath = path.join(process.env.HOST + '-' + key + '-' + spaceDetail.name.replace(/[^A-Z0-9]/ig, '_') + '.pdf')
       }
+      logger.debug('Resolved save path for export', savePath)
+      const writer = fs.createWriteStream(savePath)
+      let receivedBytes = 0
+      let totalBytes = 0
+      const options = {
+        url: downloadLink,
+        headers: { 'Content-Type': 'application/json' },
+        auth: {
+          user: process.env.USERNAME,
+          password: process.env.PASSWORD
+        }
+      }
+      logger.debug('Initiating file download with options', {
+        method: 'GET',
+        url: options.url,
+        headers: options.headers
+      })
+      request
+        .get(options)
+        .on('error', function (err) {
+          logger.error('Oops, something went wrong during download.')
+          if (logger.isVerbose() && err && err.stack) {
+            logger.error(err.stack)
+          } else {
+            logger.error(err && err.message ? err.message : err)
+          }
+          logger.timeEnd(`download:${key}`)
+          reject(err)
+        })
+        .on('response', function (data) {
+          logger.info('status code is:', data.statusCode)
+          if (data.statusCode !== 200) {
+            logger.timeEnd(`download:${key}`)
+            reject('status code is: ' + data.statusCode)
+          } else {
+            totalBytes = data.headers['content-length']
+            logger.info(key, 'space export file size:', (data.headers['content-length'] / 1048576).toFixed(2), 'MB')
+            logger.debug('Response headers:', data.headers)
+          }
+        })
+        .on('data', function (chunk) {
+          receivedBytes += chunk.length
+          downloadProgress(logger, key, receivedBytes, totalBytes)
+        })
+        .on('end', function () {
+          logger.timeEnd(`download:${key}`)
+          if ((totalBytes / 1048576).toFixed(2) > 0) {
+            logger.info(key, 'space download finished!', savePath)
+            logger.info(key, 'space download ending time:', moment().format('YYYY-MM-DD hh:mm:ss'))
+            resolve()
+          } else {
+            reject('File size does not look right, is it a empty space?')
+          }
+        })
+        .pipe(writer)
+    } catch (err) {
+      logger.error('Failed to prepare download for space', key)
+      if (logger.isVerbose() && err && err.stack) {
+        logger.error(err.stack)
+      } else {
+        logger.error(err && err.message ? err.message : err)
+      }
+      logger.timeEnd(`download:${key}`)
+      reject(err)
     }
-    request
-      .get(options)
-      .on('error', function (err) {
-        console.error('Oops, something went wrong. ', err)
-        reject(err)
-      })
-      .on('response', function (data) {
-        console.log('status code is:', data.statusCode)
-        if (data.statusCode !== 200) {
-          reject('status code is: ' + data.statusCode)
-        } else {
-          totalBytes = data.headers[ 'content-length' ]
-          console.log(key, 'space export file size:', (data.headers[ 'content-length' ] / 1048576).toFixed(2), 'MB')
-        }
-      })
-      .on('data', function (chunk) {
-        receivedBytes += chunk.length
-        downloadProgress(key, receivedBytes, totalBytes)
-      })
-      .on('end', function () {
-        if ((totalBytes / 1048576).toFixed(2) > 0) {
-          console.log(key, 'space download finished!', savePath)
-          console.log(key, 'space download ending time:', moment().format('YYYY-MM-DD hh:mm:ss'))
-          resolve()
-        } else {
-          reject('File size does not look right, is it a empty space?')
-        }
-      })
-      .pipe(writer)
   })
 }
 
-async function exportSpace (key, type) {
+async function exportSpace (key, type, options = {}) {
+  const logger = options.logger instanceof Logger ? options.logger : new Logger(options.verbose)
+  logger.time(`export:total:${key}`)
   try {
-    console.log('Generating export file for space', key, '...')
-    let downloadLink = ''
-    if (!['xml', 'pdf', 'html'].includes(type.toLowerCase())) {
-      console.error('Error: The export file type can only be xml, html or pdf.')
+    if (logger.isVerbose()) {
+      logger.debug('Verbose mode enabled. Runtime configuration:', {
+        protocol: process.env.PROTOCOL,
+        host: process.env.HOST,
+        port: process.env.PORT,
+        username: process.env.USERNAME,
+        exportType: type
+      })
+    }
+
+    logger.info('Generating export file for space', key, '...')
+    if (!type || typeof type !== 'string' || !['xml', 'pdf', 'html'].includes(type.toLowerCase())) {
+      logger.error('Error: The export file type can only be xml, html or pdf.')
       process.exit(1)
     }
-    if (type.toLowerCase() === 'xml') {
+
+    const confluence = new ConfluenceClient(process.env.PROTOCOL, process.env.HOST, process.env.PORT, process.env.USERNAME, process.env.PASSWORD, logger)
+    let downloadLink = ''
+
+    const normalizedType = type.toLowerCase()
+
+    logger.time(`export:generate:${key}`)
+    if (normalizedType === 'xml') {
+      logger.debug('Requesting XML export via Confluence API')
       downloadLink = await confluence.exportSpace2Xml({ key: key })
+      logger.debug('Raw XML export response:', downloadLink)
       downloadLink = JSON.parse(downloadLink)
+      logger.debug('Parsed XML export response:', downloadLink)
     }
-    if (type.toLowerCase() === 'html') {
-      downloadLink = await confluence.exportSpace2Html({ key: key})
+    if (normalizedType === 'html') {
+      logger.debug('Requesting HTML export via Confluence API')
+      downloadLink = await confluence.exportSpace2Html({ key: key })
+      logger.debug('Raw HTML export response:', downloadLink)
       downloadLink = JSON.parse(downloadLink)
+      logger.debug('Parsed HTML export response:', downloadLink)
     }
-    if (type.toLowerCase() === 'pdf') {
+    if (normalizedType === 'pdf') {
+      logger.debug('Requesting PDF export via Confluence API')
       downloadLink = await confluence.exportSpace2Pdf({ key: key })
+      logger.debug('PDF export response (download link):', downloadLink)
     }
-    console.log(key, 'space archiving file download link:', downloadLink)
-    console.log(key, 'space download starting time:', moment().format('YYYY-MM-DD hh:mm:ss'), '\nDownloading...')
-    await downloadExportFile(key, type, downloadLink)
+    logger.timeEnd(`export:generate:${key}`)
+
+    const linkForDownload = typeof downloadLink === 'object' && downloadLink.downloadLink ? downloadLink.downloadLink : downloadLink
+
+    logger.info(key, 'space archiving file download link:', linkForDownload)
+    logger.info(key, 'space download starting time:', moment().format('YYYY-MM-DD hh:mm:ss'), '\nDownloading...')
+
+    await downloadExportFile(logger, confluence, key, normalizedType, linkForDownload)
   } catch (err) {
-    console.log('Oops, something went wrong\n', err)
+    logger.error('Oops, something went wrong')
+    if (logger.isVerbose() && err && err.stack) {
+      logger.error(err.stack)
+    } else {
+      logger.error(err && err.message ? err.message : err)
+    }
     process.exit(1)
+  } finally {
+    logger.timeEnd(`export:total:${key}`)
   }
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,56 @@
+'use strict'
+
+class Logger {
+  constructor (verbose = false) {
+    this.verbose = Boolean(verbose)
+    this.timers = new Map()
+  }
+
+  isVerbose () {
+    return this.verbose
+  }
+
+  info (...args) {
+    console.log(...args)
+  }
+
+  warn (...args) {
+    console.warn(...args)
+  }
+
+  error (...args) {
+    console.error(...args)
+  }
+
+  debug (...args) {
+    if (this.verbose) {
+      console.log(...args)
+    }
+  }
+
+  time (label) {
+    if (!this.verbose) {
+      return
+    }
+    const key = String(label)
+    this.timers.set(key, process.hrtime.bigint())
+    console.log(`[timer:start] ${key}`)
+  }
+
+  timeEnd (label) {
+    if (!this.verbose) {
+      return
+    }
+    const key = String(label)
+    const start = this.timers.get(key)
+    if (!start) {
+      return
+    }
+    const end = process.hrtime.bigint()
+    const durationMs = Number(end - start) / 1e6
+    this.timers.delete(key)
+    console.log(`[timer:end] ${key} - ${durationMs.toFixed(2)} ms`)
+  }
+}
+
+module.exports = Logger


### PR DESCRIPTION
## Summary
- add a --verbose/-v flag to the CLI and forward the selection to the exporter
- implement a logger utility to drive detailed output and timing when verbose mode is enabled
- extend exporter and Confluence client logging and document the new option in the README

## Testing
- node cse.js --help

------
https://chatgpt.com/codex/tasks/task_b_68e454fa2b8c83309ec80c020f0e9bc2