### PR TITLE
Add CLI option to list accessible Confluence spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ Monte os valores conforme o ambiente que você estiver utilizando. Você também
 ## Uso
 
 ```
-Uso: confluence-space-exporter -k [key] -t [type]
+Uso: confluence-space-exporter -k [key] -t [type] | --list-spaces
 
 Opções:
   --help       Mostra a ajuda                                         [boolean]
   --version    Mostra a versão                                         [boolean]
   -k, --key    Chave do espaço no Confluence                         [obrigatório]
   -t, --type   Tipo de exportação: xml, html ou pdf                  [obrigatório]
+  -l, --list-spaces Lista os espaços acessíveis ao usuário autenticado [boolean]
   -v, --verbose Ativa logs detalhados para troubleshooting               [boolean]
   -e, --envvar Caminho para o arquivo de variáveis de ambiente
 
@@ -174,6 +175,8 @@ Exemplos:
   confluence-space-exporter --envvar ./envvar -k CAP -t xml
   confluence-space-exporter -k CAP -t xml --verbose
   confluence-space-exporter -k CAP -t xml -v
+  confluence-space-exporter --list-spaces
+  confluence-space-exporter -l -v
 ```
 
 ### Modo verbose
@@ -194,6 +197,28 @@ Exemplos:
 confluence-space-exporter -k SPACE_KEY -t xml --verbose
 confluence-space-exporter -k SPACE_KEY -t xml -v
 ```
+
+### Listar espaços disponíveis
+
+Utilize a flag `--list-spaces` (ou `-l`) para consultar, sem realizar exportações, todos os espaços que a conta autenticada tem permissão de visualizar. O comando pode ser combinado com `--verbose` para obter detalhes das chamadas à API.
+
+```
+confluence-space-exporter --list-spaces
+```
+
+Exemplo de saída:
+
+```
+Consulting Confluence for accessible spaces...
+Found 3 spaces:
+
+Key  Nome                    Tipo
+CAP  Espaço principal        global
+DOC  Documentação interna    global
+USR  Espaço pessoal João     personal
+```
+
+Caso nenhum espaço seja retornado ou ocorra falha de autenticação, a CLI exibirá uma mensagem de erro amigável com orientações para revisar as credenciais e a conectividade com o Confluence.
 
 ## Exemplo
 

--- a/lib/confluence-client-promise.js
+++ b/lib/confluence-client-promise.js
@@ -79,6 +79,65 @@ class ConfluenceClient {
     return this.makeRequest(options)
   }
 
+  async getAllSpaces (params = {}) {
+    const limit = params.limit || 50
+    const expand = params.expand
+    const type = params.type
+    let start = 0
+    let spaces = []
+    let keepFetching = true
+
+    if (this.logger && this.logger.isVerbose()) {
+      this.logger.debug('Fetching Confluence spaces', {
+        limit,
+        expand,
+        type
+      })
+    }
+
+    while (keepFetching) {
+      const query = {
+        start,
+        limit
+      }
+      if (type) {
+        query.type = type
+      }
+      if (expand) {
+        query.expand = expand
+      }
+
+      const options = {
+        url: `${this.baseurl}/rest/api/space`,
+        method: 'GET',
+        headers: this.headers,
+        auth: this.auth,
+        json: true,
+        qs: query
+      }
+
+      const response = await this.makeRequest(options)
+      const results = response && response.results ? response.results : []
+
+      if (this.logger && this.logger.isVerbose()) {
+        this.logger.debug('Received spaces page', {
+          start,
+          retrieved: results.length
+        })
+      }
+
+      spaces = spaces.concat(results)
+
+      if (response && response._links && response._links.next) {
+        start += limit
+      } else {
+        keepFetching = false
+      }
+    }
+
+    return spaces
+  }
+
   // Set a space status to archive
   // Params:
   // key - space key

--- a/lib/list-spaces.js
+++ b/lib/list-spaces.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const ConfluenceClient = require('./confluence-client-promise')
+const Logger = require('./logger')
+
+function renderTable (spaces) {
+  const headers = ['Key', 'Nome', 'Tipo']
+  const rows = spaces.map(space => [
+    space.key || '-',
+    space.name || '-',
+    space.type || '-'
+  ])
+
+  const columnWidths = headers.map((header, columnIndex) => {
+    const maxRowWidth = rows.reduce((max, row) => {
+      const cell = row[columnIndex]
+      const length = cell ? cell.toString().length : 0
+      return Math.max(max, length)
+    }, 0)
+    return Math.max(header.length, maxRowWidth)
+  })
+
+  const formatRow = (cells) => cells
+    .map((cell, columnIndex) => {
+      const value = cell == null ? '' : cell.toString()
+      return value.padEnd(columnWidths[columnIndex])
+    })
+    .join('  ')
+
+  const separator = columnWidths
+    .map((width) => '-'.repeat(width))
+    .join('  ')
+
+  console.log(formatRow(headers))
+  console.log(separator)
+  rows.forEach((row) => console.log(formatRow(row)))
+}
+
+async function listSpaces (options = {}) {
+  const logger = options.logger instanceof Logger ? options.logger : new Logger(options.verbose)
+
+  try {
+    const requiredEnvVars = ['PROTOCOL', 'HOST', 'PORT', 'USERNAME', 'PASSWORD']
+    const missingEnvVars = requiredEnvVars.filter((key) => !process.env[key])
+
+    if (missingEnvVars.length > 0) {
+      logger.error('Missing required environment variables to connect to Confluence:', missingEnvVars.join(', '))
+      process.exit(1)
+    }
+
+    if (logger.isVerbose()) {
+      logger.debug('Listing spaces with configuration', {
+        protocol: process.env.PROTOCOL,
+        host: process.env.HOST,
+        port: process.env.PORT,
+        username: process.env.USERNAME
+      })
+    }
+
+    const confluence = new ConfluenceClient(
+      process.env.PROTOCOL,
+      process.env.HOST,
+      process.env.PORT,
+      process.env.USERNAME,
+      process.env.PASSWORD,
+      logger
+    )
+
+    logger.info('Consulting Confluence for accessible spaces...')
+    logger.time('spaces:list')
+    const spaces = await confluence.getAllSpaces({ limit: 100 })
+    logger.timeEnd('spaces:list')
+
+    if (!Array.isArray(spaces) || spaces.length === 0) {
+      logger.error('No spaces were returned by Confluence for the authenticated user.')
+      process.exit(1)
+    }
+
+    logger.info(`Found ${spaces.length} space${spaces.length === 1 ? '' : 's'}:\n`)
+    renderTable(spaces)
+    return spaces
+  } catch (err) {
+    logger.error('Failed to list Confluence spaces.')
+    if (logger.isVerbose() && err && err.stack) {
+      logger.error(err.stack)
+    } else if (err && err.message) {
+      logger.error(err.message)
+    } else {
+      logger.error(err)
+    }
+    process.exit(1)
+  }
+}
+
+module.exports = listSpaces


### PR DESCRIPTION
## Summary
- add a `--list-spaces`/`-l` flag to the CLI so users can list the Confluence spaces available to their account without exporting content
- paginate through the Confluence REST API to collect all spaces and render a readable table, including verbose logging support and environment validation
- document the new command, usage examples, and sample output in the README

## Testing
- node cse.js --help
- node cse.js --list-spaces

------
https://chatgpt.com/codex/tasks/task_b_68e457a363608330b4f186d3abb97fb9